### PR TITLE
Clarify which user is meant.

### DIFF
--- a/tutorial-3/README.md
+++ b/tutorial-3/README.md
@@ -93,9 +93,9 @@ _FastCGI_ is a method for executing dynamic program code from a web server. It i
 
 We now have to compile two missing modules and deploy other components for the _FCGI daemon_. Let’s start with the _suEXEC module_.
 
-An Apache web server was compiled in Tutorial 1. However, although the _--enable-mods-shared=all_ option was used, _suexec_ has not been compiled yet. Hence, the module is so special that it can’t be compiled as a default module, although it is present in the source code.
+An Apache web server was compiled in Tutorial 1. However, although the _--enable-mods-shared=all_ option was used, _suexec_ has not been compiled yet. It seems, the module is so special that it can’t be compiled as a default module, although it is present in the source code.
 
-The web server configured in Tutorial 2 runs as user _www-data_ or, depending on configuration, as any other dedicated user. We would like to further restrict our dynamic application to have the separate daemon run as an additional, separate user. The _suEXEC_ module makes this possible for us. It is not absolutely required. But it adds a bit more security with little extra effort.
+The web server configured in Tutorial 2 runs as user _www-data_ or, depending on configuration, as any other dedicated user. We would like to further restrict our dynamic application to have the separate daemon run as an additional, separate user that is introuced below in step 5. The _suEXEC_ module makes this possible for us. It is not absolutely required. But it adds a bit more security with little extra effort.
 
 Let’s enter the directory with the Apache source code and compile the server once more. 
 
@@ -103,7 +103,7 @@ Let’s enter the directory with the Apache source code and compile the server o
 $> cd /usr/src/apache/httpd-2.4.29
 $> ./configure --prefix=/opt/apache-2.4.29 --enable-mods-shared=all \
    --with-apr=/usr/local/apr/bin/apr-1-config \
-   --with-apr-util=/usr/local/apr/bin/apu-1-config --enable-mpms-shared="event worker" \
+   --with-apr-util=/usr/local/apr/bin/apu-1-config --enable-mpms-shared="event" \
    --enable-nonportable-atomics=yes --enable-suexec --with-suexec-caller=www-data \
    --with-suexec-docroot=/opt/apache-2.4.29/bin && make && sudo make install
 ```

--- a/tutorial-3/README.md
+++ b/tutorial-3/README.md
@@ -95,7 +95,7 @@ We now have to compile two missing modules and deploy other components for the _
 
 An Apache web server was compiled in Tutorial 1. However, although the _--enable-mods-shared=all_ option was used, _suexec_ has not been compiled yet. It seems, the module is so special that it can’t be compiled as a default module, although it is present in the source code.
 
-The web server configured in Tutorial 2 runs as user _www-data_ or, depending on configuration, as any other dedicated user. We would like to further restrict our dynamic application to have the separate daemon run as an additional, separate user that is introuced below in step 5. The _suEXEC_ module makes this possible for us. It is not absolutely required. But it adds a bit more security with little extra effort.
+The web server configured in Tutorial 2 runs as user _www-data_ or, depending on configuration, as any other dedicated user. We would like to further restrict our dynamic application to have the separate daemon run as an additional, separate user that is introduced in one of the next steps. The _suEXEC_ module makes this possible for us. It is not absolutely required. But it adds a bit more security with little extra effort.
 
 Let’s enter the directory with the Apache source code and compile the server once more. 
 


### PR DESCRIPTION
> ### Unclear

> The web server configured in Tutorial 2 runs as user www-data or, depending
> on configuration, as any other dedicated user. **We would like to further
> restrict our dynamic application to have the separate daemon run as an
> additional, separate user.** The suEXEC module makes this possible for us.
> It is not absolutely required. But it adds a bit more security with little
> extra effort.
>
> Which user is that and where is this reflected in the configuration?

In the tutorial in step 5 and 6. Is it really unclear for you?


It does become clear once you know which user is referenced in that sentence. Before it is pointed out, however,  it is not clear (at least it wasn't clear to me when I arrived at that point in the tutorial). The referenced user is only introduced quite a bit later but the way it is described it sounds as if it would be part of the next ./configure command that is coming up.