### PR TITLE
Adding a space after all the title tags in all tutorials

### DIFF
--- a/tutorial-1/README.md
+++ b/tutorial-1/README.md
@@ -1,14 +1,14 @@
-##Compiling an Apache web server
+## Compiling an Apache web server
 
-###What are we doing?
+### What are we doing?
 
 We're compiling an Apache web server for a test system.
 
-###Why are we doing this?
+### Why are we doing this?
 
 In professional use of the web server it’s very often the case that special requirements (security, additional debugging messages, special features from a new patch, etc.) force you to leave behind the distribution packages and quickly create some binaries on your own. In this case it’s important for the infrastructure to be prepared and to already have experience compiling and running your own binaries on production systems. It’s also easier to work with self-compiled Apache in a laboratory-like setup, which is also beneficial in terms of debugging.
 
-###Step 1: Preparing the directory tree for the source code
+### Step 1: Preparing the directory tree for the source code
 
 It’s not all that important where the source code is located. The following is a recommendation based on the [File Hierarchy Standard](http://www.pathname.com/fhs/). The FHS defines the path structure of a Unix system; the structure for all stored files. Note that in the second command `` `whoami` `` evaluates to the username and not root (despite `sudo`).
 
@@ -18,7 +18,7 @@ $> sudo chown `whoami` /usr/src/apache
 $> cd /usr/src/apache
 ```
 
-###Step 2: Meeting the requirements for apr and apr-util
+### Step 2: Meeting the requirements for apr and apr-util
 
 Since the release of version 2.4, the Apache web server comes without two important libraries that used to be part of the distribution. We now have to install `apr` and `apr-util` ourselves before being able to compile Apache. `apr` is the Apache Portable Runtime library. It adds additional features to the normal set of C libraries typically needed by server software. They include features for managing hash tables and arrays. These libraries aren’t used by the Apache web server alone, but also by other Apache Software Foundation projects, which is why they were removed from Apache’s source code. Like `apr`, `apr-util` is part of the Portable Runtime libraries supplemented by `apr-util`.
 
@@ -99,7 +99,7 @@ $> sudo make install
 
 Once this works in both cases we're ready for the web server itself.
 
-###Step 3: Downloading the source code and verifying the checksum
+### Step 3: Downloading the source code and verifying the checksum
 
 We’ll now download the program code from the internet. This can be done by downloading it directly from [Apache](https://httpd.apache.org/) in a browser or, to save the Apache Project’s bandwidth, by using wget to get it from a mirror.
 
@@ -118,7 +118,7 @@ $> sha1sum --check httpd-2.4.29.tar.bz2.sha1
 httpd-2.4.29.tar.bz2: OK
 ```
 
-###Step 4: Unpacking and configuring the compiler
+### Step 4: Unpacking and configuring the compiler
 
 After verification we can unpack the package.
 
@@ -145,7 +145,7 @@ We then define that we want all (_all_) modules to be compiled. Of note here is 
 
 When executing the _configure_ command for the web server, it may be necessary to install additional packages. However, if you have installed all those named in the second step, you should be covered.
 
-###Step 5: Compiling
+### Step 5: Compiling
 
 Once _configure_ is completed, we are ready for the compiler. Nothing should go wrong any longer at this point.
 
@@ -155,7 +155,7 @@ $> make
 
 This takes some time and 38 MB becomes just under 100 MB.
 
-###Step 6: Installing
+### Step 6: Installing
 
 When compiling is successful, we then install the Apache web server we built ourselves. Installation must be performed by the super user. But right afterwards we’ll see how we can again take ownership of the web server. This is much more practical for a test system.
 
@@ -179,7 +179,7 @@ $> cd /apache
 
 Our web server now has a pathname clearly describing it by version number. We will however simply use `/apache` for access. This makes work easier.
 
-###Step 7: Starting
+### Step 7: Starting
 
 Now let’s see if our server will start up. For the moment, this again has to be done by the super user:
 
@@ -198,7 +198,7 @@ AH00558: httpd: Could not reliably determine the server's fully qualified domain
 
 This is unimportant and we can ignore the warning for the time being.
 
-###Step 8: Trying it out
+### Step 8: Trying it out
 
 The engine is running. But is it also working? Time for the function test: We access Apache by entering the following URL in our browser:
 
@@ -214,7 +214,7 @@ Fantastic! Goal achieved: The self-compiled Apache is running.
 
 Return to the shell and stop the server via CTRL-C.
 
-###Step 9 (Goodie): Inspecting the binaries and the modules
+### Step 9 (Goodie): Inspecting the binaries and the modules
 
 Before completing the tutorial, we’d like to take a closer look at the server. Let’s open the engine compartment and take a peek inside. We can get information about our binary as follows:
 
@@ -386,7 +386,7 @@ total 8.8M
 
 These are all of the modules distributed along with the server by Apache and we are well aware that we selected the _all_ option for the modules to compile. Additional modules are available from third parties. We don’t need all of these modules, but there are some you'll almost always want to have: They are ready to be included.
 
-###References
+### References
 - Apache: [https://httpd.apache.org](https://httpd.apache.org)
 - File Hierarchy Standard: [http://www.pathname.com/fhs/](http://www.pathname.com/fhs/)
 - Apache ./configure documentation: [https://httpd.apache.org/docs/trunk/programs/configure.html](https://httpd.apache.org/docs/trunk/programs/configure.html)

--- a/tutorial-10/README.md
+++ b/tutorial-10/README.md
@@ -1,17 +1,17 @@
-##Efficiently configuring and debugging Apache and ModSec in the shell
+## Efficiently configuring and debugging Apache and ModSec in the shell
 
-###What are we doing?
+### What are we doing?
 
 We are setting up shell tools and a method enabling us to efficiently edit Apache configurations and test them in just a few seconds without using a browser or having to constantly search through files by hand.
 
-###Why are we doing this?
+### Why are we doing this?
 
 Successfully configuring the Apache web server requires a lot of know-how and experience. When ModSecurity is added and intervenes in processing this make configuration even more complicated. That’s why it’s necessary to set up the right tools and a systematic workflow. This is the objective of this tutorial.
 
 The tutorial is a bit pedantic, since it takes optimizing individual key presses in all seriousness. Since dozens, if not hundreds of actions have to be initiated in sequence in the configuration of a web server, there is plenty of room for optimizing the workflow, as ridiculous as it may seem. The advantage of this is that we can remove unnecessary ballast, clearing the view to the actual configuration problem. To this end this tutorial will be presenting some tricks and ideas that promise to be of benefit.
 
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling an Apache web server)](https://www.netnea.com/cms/apache_tutorial_1_apache_compilieren/).
 * Understanding of the minimal configuration in [Tutorial 2 (Configuring a minimal Apache server)](https://www.netnea.com/cms/apache_tutorial_2_apache_minimal_konfigurieren/).
@@ -21,7 +21,7 @@ The tutorial is a bit pedantic, since it takes optimizing individual key presses
 * An Apache web server with Core Rules installation as in [Tutorial 7 (Embedding Core Rules)](http://www.netnea.com/cms/modsecurity-core-rules-einbinden/)
 
 
-###Step 1: Curl
+### Step 1: Curl
 
 Curl is the right tool for making HTTP requests. HTTP must of course first work in the browser or the application. But when debugging or configuring new features the browser normally proves to be very cumbersome. Cooking handling, the size of the window, automatically following redirects, etc. all contribute towards making work in the browser very time consuming. That’s why when you have identified a problem in the browser it’s better to reproduce it using `curl`, find the bug, fix it in the server configuration and finally, verify it in the browser.
 
@@ -39,7 +39,7 @@ $> curl http://localhost/login.html --next --cookie-jar /tmp/cookies.txt --cooki
 The first example works with a cookie file, writes the cookies received and reads new requests from the cookies. In the second example, which works only with a relatively new version of `curl`, multiple requests are put together on a single line. What’s interesting is the `--next` option dividing the command line arguments. The parameters following `--next` apply only to the right. This means that the rules above initially made a GET request, and then followed with a POST request on the same TCP connection and afterwards stored the session cookie in the cookie jar.
 
 
-###Step 2: Single Apache configuration file
+### Step 2: Single Apache configuration file
 
 The Apache configuration used in this series of tutorials is intended for the lab. By this I mean a test environment in which you can quickly try out the configuration or perform debugging regardless of productive HTTP traffic. One essential feature of the Apache configuration being used was the method for accommodating the entire configuration (with the exception of the OWASP ModSecurity Core Rules) in one file. The advantage of this is that we are able to quickly find our way around in the file and get to specific passages via standard search commands. However, this principle is not only beneficial in a lab-like setting. Working this way is also useful in a production environment for eliminating most conflicts and redundancies. This however runs counter to the widespread trend towards modularization of the web server configuration into a variety of files and induces errors. Indeed, I have many times been confronted by setups that configured the VirturalHosts multiple times, set up conflicting access restrictions and whose administrators seemed surprised to learn that the directives configured were being overridden in other places. This is the reason why whenever possible I try to work on one configuration in a single file.
 
@@ -54,7 +54,7 @@ $> vim httpd.conf_problem-of-the-day
 
 `Vim` is perfectly suited for editing Apache configurations, but the editor does not play such a key role so long as it supports syntax highlighting, which in my opinion is an invaluable feature.
 
-###Step 3: Apachex
+### Step 3: Apachex
 
 `curl` and a single Apache file provide us a good foundation for quickly customizing configurations and testing them just as fast. This usually involves a somewhat annoying step between these often repeated steps: restarting the web server. In the first two tutorials we started the sever each time using the `-X` command line flag. I often work with `-X`, because it does not put the server into daemon mode and instead allows it to run as a single process in the foreground. Any server crash shows up immediately in the shell. If we start the web server as usual and run it as a daemon, we then have to watch the error log and make sure that we don’t miss a crash, which can involve all kinds of strange effects. Although it's possible to monitor for crashes this way, in my experience it is a surprisingly serious drawback. So I work with `-X`.
 
@@ -114,7 +114,7 @@ Press [enter] to restart apache, enter [q] to stop apache and exit: q
 Bailing out ... ok
 
 ``` 
-###Step 4: lastrequestsummary
+### Step 4: lastrequestsummary
 
 We still lack intelligent access to the log files. `curl -v` does provide us feedback about the results of a request, but with ModSecurity rules it’s important to be able to follow processing on the server side. And with its chatty and unclear log file entries, ModSecurity poses a challenge, especially since a single request can quickly generate more logging that can fit in a window and most of this information is of no interest. What we are missing is a summary of a request including information from both the `access log` and the `error log`. The `lastrequestsummary` adds just such an analysis ([lastrequestsummary](https://github.com/Apache-Labor/labor/blob/master/bin/lastrequestsummary)):
 
@@ -246,7 +246,7 @@ watch --interval 1 --no-title "lastrequestsummary /apache/logs/access.log /apach
 ```  
 Particularly for production use, it is also advisable to adjust the file names here, or to have an intelligent search process set them automatically.
 
-###Step 5: Dividing the screen into 4 sections
+### Step 5: Dividing the screen into 4 sections
 
 In the preceding four steps we have seen how to configure Apache, easily start it, talk to it as efficiently as possible and finally, to check its behavior in the log files. It’s time to assign each of these steps to its own shell window. This brings us to a classic four-window setup which has proven to be very efficient in practice. Provided enough screen space is available, there’s nothing against trying a 6 or 9-window setup, unless you’d lose track of things by doing so.
 
@@ -265,7 +265,7 @@ Here’s a screenshot of my desktop:
 
 ![Screenshot: 4 Shells](https://www.netnea.com/files/4-shells-screenshot.png)
 
-###References
+### References
 
 * [apachex](https://raw.githubusercontent.com/Apache-Labor/labor/master/bin/apachex)
 * [lastrequestsummary](https://raw.githubusercontent.com/Apache-Labor/labor/master/bin/lastrequestsummary)

--- a/tutorial-11/README.md
+++ b/tutorial-11/README.md
@@ -1,10 +1,10 @@
-##Visualizing Apache and ModSecurity Log Files
+## Visualizing Apache and ModSecurity Log Files
 
-###What are we doing?
+### What are we doing?
 
 We are interpreting the log files visually.
 
-###Why are we doing this?
+### Why are we doing this?
 
 In the preceding tutorials we have customized the Apache log format and performed a variety of statistical analyses. But we have yet to graphically display the numbers obtained. The visualization of data does in fact provide a big help in identifying problems. In particular, time series are very informative and even performance problems can be better quantified and narrowed down visually. But graphical display can also provide interesting information about false positives among the volumes of ModSecurity alarms.
 
@@ -12,7 +12,7 @@ The benefit of visualization is readily apparent and is a good reason why graphs
 
 For this reason, we will be using a little-known feature of `gnuplot`.
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling an Apache web server)](https://www.netnea.com/cms/apache_tutorial_1_apache_compilieren/).
 * Understanding of the minimal configuration in [Tutorial 2 (Configuring a minimal Apache server)](https://www.netnea.com/cms/apache_tutorial_2_apache_minimal_konfigurieren/).
@@ -22,7 +22,7 @@ For this reason, we will be using a little-known feature of `gnuplot`.
 * An Apache web server with Core Rules installation as in [Tutorial 7 (Embedding Core Rules)](http://www.netnea.com/cms/modsecurity-core-rules-einbinden/)
 * The `gnuplot` package; e.g. as present in the `Ubuntu` distribution.
 
-###Step 1: Graphically displaying time series in the shell
+### Step 1: Graphically displaying time series in the shell
 
 The appearance of entries in log files follows a chronological sequence. However, it is actually relatively difficult to follow this chronological sequence in the text file. Visualization of the log files is the answer. Dashboards have already been mentioned and a variety of commercial products and open source projects have become established in the past few years. These tools are very useful. But they are not always easily accessible or the log data must first be imported and sometimes even converted or indexed. There is thus a big gap in displaying graphs in the shell. The graphical tool `gnuplot` can in fact do this in ASCII and be controlled completely from the command line.
 
@@ -105,7 +105,7 @@ A serious drawback is the useless labeling on the x-axis, since the numbers from
 
 But because we had gaps in the dataset our data is based on, we can no longer infer the time of a value from the number of lines and hence the x-axis in the graph. We’ll first have to close these gaps, then have a closer look at the x-axis problem.
 
-###Step 2: Filling in the gaps on the timeline
+### Step 2: Filling in the gaps on the timeline
 
 The problem with the gaps is that for some hours we don’t have a single request in the log file. The log file comes from a server with relatively little traffic. But filtering the log file after an error on a server with significantly more traffic results in gaps appearing in the timeline. We have to close them for good. Up to now we have extracted the date and time from the log file. The approach has proven to be inadequate:
 Instead of deriving the sequence of dates and hours from the log file, we will be rebuilding it ourselves and looking for the number of requests in the log file for every date and hour combination. A repetitive `grep` on the same log file would be a bit inefficient, but entirely suitable for the size of the log file in this case. The approach must be optimized for larger files.
@@ -194,7 +194,7 @@ echo "$COUNT $STRING "; done | arbigraph
 There now appears to be a degree of regularity, because every 24 values is an entire day. Knowing this, we see the daily rhythm, can surmise Saturday and Sunday and may even see indications of a specific lunch break.
 
 
-###Step 3: X-axis label
+### Step 3: X-axis label
 
 The gaps are closed. Let’s get to the specific labeling of the x-axis. `arbigraph` is able to read labels from the input. It identifies the labels on its own; but for this purpose they must be separated by a tab from the actual data. `echo` does this for us when we set the `escape flag`
 
@@ -390,7 +390,7 @@ This gives use the desired graph. One detail are the many plus signs in the top 
 
 
 
-###Step 4: Additional labels
+### Step 4: Additional labels
 
 `arbigraph` provides some options for influencing graphs. Let’s have a look at the options:
 
@@ -545,7 +545,7 @@ $> cat gnuplot-script.gp | gnuplot
 Provided you have sufficient expertise in using gnuplot, you can now carry on and generate a "report-ready" graph.
 
 
-###Step 5: Graphically displaying a value distribution in the shell
+### Step 5: Graphically displaying a value distribution in the shell
 
 Besides time series, our `arbigraph` combined with `gnuplot` can also visually render the distribution of values. Let’s look for example at the duration value documented in the different requests.
 
@@ -760,7 +760,7 @@ $> paste  /tmp/tmp.get /tmp/tmp.post | awk '{ print $1 "\t"  $2 " " $4 }' \
 
 We are now working with two separate data files, which we separate via the `paste` Unix command. Afterwards we use `awk` and tab to get the labels into the data and to remove the label repeated in the third column of data. The display of two values no longer works in blocking mode, which is why we are again relying on lines. The two lines are drawn over each over on differing scales. This enables a good comparison. Less surprisingly, POST requests take a bit longer. What is surprising is that they last so little longer that the GET requests.
 
-###Step 6 (Goodie): Output at different widths and as a PNG
+### Step 6 (Goodie): Output at different widths and as a PNG
 
 `arbigraph` adapts to the width of the terminal for output. If it should be narrower, this can be controlled via the `--width` option. Similarly, the height can be adjusted via `--height`. Export as a PNG image is also included in the script. Export is still rather rudimentary, but the resulting images may be good enough to use in a report.
 
@@ -774,7 +774,7 @@ Plot written to file /tmp/duration-get-vs-post.png.
 ![Graph: Gnuplot with PNG Terminal](https://www.netnea.com/files/duration-get-vs-post.png)
 
 
-###References
+### References
 
 * [gnuplot](http://www.gnuplot.info)
 * [arbigraph](https://raw.githubusercontent.com/Apache-Labor/labor/master/bin/arbigraph)

--- a/tutorial-12/README.md
+++ b/tutorial-12/README.md
@@ -1,15 +1,15 @@
-##Capturing and decrypting the entire traffic
+## Capturing and decrypting the entire traffic
 
-###What are we doing?
+### What are we doing?
 
 We are capturing the entire HTTP traffic. We will also be decrypting traffic where necessary.
 
-###Why are we doing this?
+### Why are we doing this?
 
 
 In daily life, when operating a web or reverse proxy server errors occur that can only be handled with difficultly come up again and again. In numerous cases there is a lack of clarity about what has just passed over the line or there is disagreement about exactly which end of communication was responsible for the error. In cases such as these it is important to be able to capture the entire traffic in order to narrow down the error to this basis.
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling an Apache web server)](https://www.netnea.com/cms/apache_tutorial_1_apache_compilieren/).
 * Understanding of the minimal configuration in [Tutorial 2 (Configuring a minimal Apache server)](https://www.netnea.com/cms/apache_tutorial_2_apache_minimal_konfigurieren/).
@@ -19,7 +19,7 @@ In daily life, when operating a web or reverse proxy server errors occur that ca
 * An OWASP ModSecurity Core Rules installation as in [Tutorial 7 (Embedding ModSecurity Core Rules](https://www.netnea.com/cms/apache-tutorial-7-modsecurity-core-rules-einbinden/)
 * A reverse proxy as in [Tutorial 9 (Setting up a reverse proxy)](https://www.netnea.com/cms/apache-tutorial-9-reverse-proxy-einrichten/)
 
-###Step 1: Using ModSecurity to capture the entire traffic
+### Step 1: Using ModSecurity to capture the entire traffic
 
 In Tutorial 6 we saw how we are able to configure ModSecurity to capture the entire traffic from a single client IP address. However, depending on the settings of the `SecAuditLogParts` directive, not all parts of the requests are recorded. Let’s have a look at the different options in this directive: The ModSecurity audit engine labels different parts of the audit log using different letter abbreviations. They are as follows:
 
@@ -53,7 +53,7 @@ SecRule REMOTE_ADDR  "@streq 127.0.0.1"   \
 	"id:10000,phase:1,pass,log,auditlog,msg:'Initializing full traffic log',ctl:auditLogParts=+EIJ"
 ```
 
-###Step 2: Using ModSecurity to write the entire traffic of a single session
+### Step 2: Using ModSecurity to write the entire traffic of a single session
 
 The first step enables the dynamic modification of audit log parts for a known IP address. But what if we want to permanently enable dynamic logging for selected sessions and, as shown in the example above, expand it to the entire request?
 
@@ -83,7 +83,7 @@ Forcing the audit log, which we have not yet become familiar with, is required, 
 
 Altogether, these three rules enable us to precisely monitor a conspicuous client beyond an individual suspicious request and to capture the entire client traffic in the audit log once suspicion has been aroused.
 
-###Step 3: Sniffing client traffic with the server/reverse proxy
+### Step 3: Sniffing client traffic with the server/reverse proxy
 
 Traffic between the client and the reverse proxy can normally be well documented using the methods described. In addition, we have the option of documenting traffic on the client. Modern browsers provide options for this and they all seem adequate to me. In practice however there are complications that can make capturing traffic difficult or impossible. Be it a fat client being used outside a browser, the client being used only on a mobile device with an interposed proxy modifying traffic in one direction or the other in such a way that traffic is being modified once more by another module after leaving ModSecurity or that ModSecurity has no access to traffic whatsoever. In individual cases the latter is actually a problem, because an Apache module can abort the processing of a request and suppress access from ModSecurity by doing so.
 
@@ -112,7 +112,7 @@ In the fourth tutorial we operated the local Laboratory Service using the local 
 
 ```
 
-###Step 4: Capturing encrypted traffic between the client and the server/reverse proxy
+### Step 4: Capturing encrypted traffic between the client and the server/reverse proxy
 
 
 The explanations above set the stage for capturing and then decrypting traffic. We’ll be doing it in two steps, first logging the traffic and then decrypting the log. Capturing is also called `pulling a PCAP`. This means we are providing a `PCAP` file, or a network traffic log in `PCAP` format. `PCAP` means `packet capture`. For this we'll either be using the most widespread tool, `tcpdump`, or `tshark` from the `Wireshark` suite. It is also possible to work right away in the `Wireshark` graphical interface.
@@ -175,7 +175,7 @@ tcpdump: listening on lo, link-type EN10MB (Ethernet), capture size 65535 bytes
 0 packets dropped by kernel
 ```
 
-###Step 5: Decrypting traffic
+### Step 5: Decrypting traffic
 
 Let’s try to decrypt the `PCAP` file. We’ll again be using `tshark` from the `Wireshark` suite. The `GUI` also works, but is less comfortable. What’s important now is to pass the key we used on the server to the tool.
 
@@ -282,7 +282,7 @@ ssl_decrypt_record found padding 8 final len 247
 The HTTP traffic is now legible, even if in a somewhat difficult format.
 
 
-###Step 6: Sniffing traffic between the reverse proxy and the application server
+### Step 6: Sniffing traffic between the reverse proxy and the application server
 
 The ModSecurity audit log is written after the response to a request is sent. This already makes it clear that the audit log is primarily interesting for what may possibly be the final version of the response. On a reverse proxy this version of the request and above all the response do not necessarily match what the backend system actually sent, because the different Apache modules may have already intervened in the traffic. In order to capture this traffic we will be needing something else. The `mod_firehose` module is present in the development branch of the Apache web server.  It can be used to capture and log virtually any place in the traffic. However, the developer community has decided not to include the module in Apache 2.4, but to wait until a later version.
 
@@ -569,7 +569,7 @@ E..4..@.@.\............@...........^.(.....
 
 We’ve done it! We are capturing the connection to the backend and are now sure about the traffic being exchanged between the two servers. In practice it is often unclear whether an error is actually being caused on the application server or perhaps on the reverse proxy after all. Using this construct that does not touch the SSL configuration of the backend server, we have a tool giving us a final answer in these relatively frequent cases.
 
-###References
+### References
 
 * [Ivan Ristić: ModSecurity Handbook](https://www.feistyduck.com/books/modsecurity-handbook/)
 * [Mod_firehose](http://httpd.apache.org/docs/trunk/de/mod/mod_firehose.html)

--- a/tutorial-2/README.md
+++ b/tutorial-2/README.md
@@ -1,19 +1,19 @@
-##Configuring a minimal Apache server
+## Configuring a minimal Apache server
 
-###What are we doing?
+### What are we doing?
 
 We are configuring a minimal Apache web server and will occasionally be talking to it with curl, the TRACE method and ab.
 
-###Why are we doing this?
+### Why are we doing this?
 
 A secure server is one that permits only as much as what is really needed. Ideally, you would build a server based on a minimal system by enabling additional features individually. This is also preferable in terms of understanding what’s going on, because this is the only way of knowing what is really configured.
 Starting with a minimal system is also helpful in debugging. If the error is not present in the minimal system, features are added individually and the search for the error goes on. When the error occurs, it is identified to be related to the last configuration directive added.
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling an Apache web server)](https://www.netnea.com/cms/apache-tutorial-1_compiling-apache).
 
-###Step 1: Creating a minimal configuration
+### Step 1: Creating a minimal configuration
 
 Our web server is stored in `/apache` on the file system. Its default configuration is located in `/apache/conf/httpd.conf`. It is very extensive and contains many comments and commented out configuration lines. This makes it rather difficult to understand but at least everything is still in a single file. For packaged versions of Apache, on many Linux distributions, the default configuration is not only very complicated, it is also fragmented into a handful of separate files that are spread across multiple directories. This can make it hard to get a good overview of what is actually going on.
 To simplify things, we will be replacing this extensive configuration file with the following, greatly simplified configuration.
@@ -74,7 +74,7 @@ DocumentRoot            /apache/htdocs
 </VirtualHost>
 ```
 
-###Step 2: Understanding the configuration
+### Step 2: Understanding the configuration
 
 Let’s go through this configuration step-by-step.
 
@@ -136,7 +136,7 @@ Let’s now open up a _VirtualHost_. It corresponds to the _Listen_ directive de
 
 Specifically, we permit access to our _DocumentRoot_. The final instruction here is _Require all granted_, where unlike the _/_ directory we permit full access. Unlike above, from this path on no provision is made for symlinks or any special capabilities: _Options None_.
 
-###Step 3: Starting the server
+### Step 3: Starting the server
 
 Our minimal server has thus been described. It would be possible to define a server that is even more bare bones. It would however not be as comfortable to work with as ours and it wouldn’t be any more secure. A certain amount of basic security is however advisable. This is because in the lab we are building a service which should then with specific adjustments be able to be put into a production environment. Wanting to secure a service from top to bottom right before entering a production environment is illusory.
 
@@ -150,7 +150,7 @@ $> cd /apache
 $> sudo ./bin/httpd -X
 ```
 
-###Step 4: Talking to the server using curl
+### Step 4: Talking to the server using curl
 
 Now we can again communicate with the server from a web browser. But working in the shell at first can be more effective, making it easier to understand what is going on.
 
@@ -166,7 +166,7 @@ Returns the following:
 
 We have thus sent an HTTP request and have received a response from our minimally configured server, meeting our expectations.
 
-###Step 5: Examining requests and responses
+### Step 5: Examining requests and responses
 
 This is what happens during an HTTP request. But what exactly is the server saying to us? To find out, let’s start _curl_. This time with the _verbose_ option.
 
@@ -212,7 +212,7 @@ The server will then tell us when the file the response is based on was last cha
 
 Incidentally, the order of these headers is characteristic for web servers. _NginX_ uses a different order and, for instance, puts the _server header_ in front of the date. Apache can still be identified even if the server line is intended to be misleading.
 
-###Step 6: Examining the response a bit more closely
+### Step 6: Examining the response a bit more closely
 
 During communication it is possible to get a somewhat more detailed view in _curl_. We use the _--trace-ascii_ command line parameter to do this:
 
@@ -254,7 +254,7 @@ _--trace-ascii_ requires a file as a parameter in order to make an _ASCII dump_ 
 
 Compared to _verbose_, _trace-ascii_ provides more details about the number of transferred bytes in the _request_ and _response_ phase. The request headers in the example above are thus 83 bytes. The bytes are then listed for each header in the response and overall for the body in the response: 45 bytes. This may seem like we are splitting hairs. But in fact, it can be crucial when something is missing and it is not quite certain what or where in the sequence it was delivered. Thus, it’s worth noting that 2 bytes are added to each header line. These are the CR (carriage returns) and NL (new lines) in the header lines included in the HTTP protocol. In the response body, on the other hand, only the actual content of the file is returned. This is obviously only one NL without CR here. On the third to last line (_000: <html ..._) a point comes after the greater than character This is code for the NL character in the response, which like other escape sequences is output in the form of a point.
 
-###Step 7: Working with the trace method
+### Step 7: Working with the trace method
 
 The _TraceEnable_ directive was described above. We have turned it _off_ as a precaution. It can however be very useful in debugging. So, let’s give it a try. Let’s set the option to on:
 
@@ -298,7 +298,7 @@ In the _body_ the server repeats the information about the request sent to it as
 
 Don’t forget to turn _TraceEnable_ off again.
 
-###Step 8: Using "ab" to test the server
+### Step 8: Using "ab" to test the server
 
 So much for the simple server. But just for fun we can put it to the test. We’ll perform a small performance test using _ab_, short for _ApacheBench_. This is a very simple benchmarking program that is always at hand and able to quickly give you initial performance results. I like to run it before and after a configuration change to get an idea about whether anything in terms of performance has changed. _ab_ is very powerful and calling it locally does not give you clean results. But you can get an initial impression using this tool.
 
@@ -368,7 +368,7 @@ Percentage of the requests served within a certain time (ms)
 
 What’s of primary interest to us is the number of errors (_Failed requests_) and the number of requests per second (_Requests per second_). A value above one thousand is a good start. Especially considering that we are still working with a single process and not a parallelized daemon (which is also why the _concurrency level_ is set to 1).
 
-###Step 9 (Goodie): Viewing directives and modules
+### Step 9 (Goodie): Viewing directives and modules
 
 At the end of this tutorial we are going to be looking at a variety of directives, which an Apache web server started with our configuration file is familiar with, The different loaded modules extend the server’s set of commands. The available configuration parameters are well documented on the Apache Project’s website. In fact, in special cases it can however be helpful to get an overview of the directives made available from the loaded modules. You can get the directives by using the command line flag _-L_.
 
@@ -421,7 +421,7 @@ The _authn_core_ module is thus not being used. This is correct, we described it
 So much for this tutorial. You now have a capable server you can work with. We will continue to extend it in subsequent tutorials.
 
 
-###References
+### References
 
 * Apache: http://httpd.apache.org
 * Apache directives: http://httpd.apache.org/docs/current/mod/directives.html

--- a/tutorial-3/README.md
+++ b/tutorial-3/README.md
@@ -1,20 +1,20 @@
-##Setting up an Apache/PHP application server
+## Setting up an Apache/PHP application server
 
-###What are we doing?
+### What are we doing?
 
 We are setting up an Apache/PHP application server using the minimal number of modules necessary.
 
-###Why are we doing this?
+### Why are we doing this?
 
 A bare bones Apache server is suitable for delivering static files. More complex applications rely on dynamic content. This requires an extension of the server. A very fast and secure application server can be implemented using _suEXEC_, an external _FastCGI daemon_ and _PHP_. This is by far not the only option and also likely not the most widespread one in a corporate environment. But is a very simple architecture perfectly suited for a test system.
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling an Apache web server)](https://www.netnea.com/cms/apache-tutorial-1_compiling-apache/).
 * Understanding of the minimal configuration in [Tutorial 2 (Configuring a minimal Apache server)](http://www.netnea.com/cms/apache-tutorial-2_minimal-apache-configuration).
 
 
-###Step 1: Configuring Apache
+### Step 1: Configuring Apache
 
 We’ll configure the web server to start off with, aware of the fact that it is not yet capable of running in this configuration. Based on the minimal web server described in Tutorial 2, we’ll configure a very simple application server in the *conf/httpd.conf_fastcgid* file.
 
@@ -89,7 +89,7 @@ The _/apache/htdocs_ directory now needs the additional _ExecCGI_ option. And fi
 
 _FastCGI_ is a method for executing dynamic program code from a web server. It is a very fast method which for the most part leaves the server untouched and runs the application on a separate daemon. To increase the speed, _FastCGI_ provides multiple instances of this daemon, allowing requests to be processed without having to wait. In practice, this is a promising gain in performance and, more importantly, an architecture that saves memory, as will be discussed in more detail below.
 
-###Step 2: Compiling Apache with suEXEC support
+### Step 2: Compiling Apache with suEXEC support
 
 We now have to compile two missing modules and deploy other components for the _FCGI daemon_. Let’s start with the _suEXEC module_.
 
@@ -114,7 +114,7 @@ If successfully configured, the command line above will start the compiler and a
 
 By the way, if you make a mistake in the configuration above and want to assign _suexec_ different compiler constants, you’ll first have to clean out the compiler environment before compiling again. The new options will otherwise be ignored. We can do this via the _make clean_ command in front of _configure_ or by manually deleting the files _support/suexec_, _support/suexec.lo_ and _support/suexec.o_, which is faster, because the whole web server no longer has to be built from scratch.
 
-###Step 3: Downloading and compiling the FastCGI module
+### Step 3: Downloading and compiling the FastCGI module
 
 The _FastCGI module_ is managed by Apache. But it is not part of the normal source code for the web server. So, let’s download the source code for the additional module and verify the loaded checksum over an encrypted connection.
 
@@ -148,13 +148,13 @@ $> sudo mkdir /apache/logs/fcgidsock
 $> sudo chown www-data:www-data /apache/logs/fcgidsock
 ```
 
-###Step 4: Installing and preconfiguring PHP
+### Step 4: Installing and preconfiguring PHP
 
 Up till now we have been compiling all of the software piece by piece. But for the entire PHP stack a limit has been reached. No one should be prevented from compiling PHP on his own, but we are concentrating on the web server here and for this reason will be using this piece of software from the Linux distribution. In Debian/Ubuntu the package we need is _php7.0-cgi_, which comes along with _php7.0-common_.
 
 Properly configuring _PHP_ is a broad topic and I recommend consulting the relevant pages, because an improperly configured installation of _PHP_ may pose a serious security problem. I don’t wish to give you any more information at this point, because it takes us away from our actual topic, which is a simple application server. For operation on the internet, i.e. no longer in a lab-like setup, it is highly recommended to become familiar with the relevant PHP security settings.
 
-###Step 5: Creating the CGI user
+### Step 5: Creating the CGI user
 
 Above it has already been discussed that we are planning to start a separate daemon to process _PHP requests_. This daemon should be started via _suexec_ and run as separate user. We create the user as follows:
 
@@ -165,7 +165,7 @@ $> sudo useradd -s /bin/false -d /apache/htdocs -m -g fcgi-php fcgi-php
 
 It can be expected for a warning to appear concerning the presence of the _/apache/htdocs_ directory. We can ignore it.
 
-###Step 6: Creating a PHP wrapper script
+### Step 6: Creating a PHP wrapper script
 
 It is normal to use a wrapper script for _PHP_ and _FCGI_ to work together. We already set this up in the Apache configuration above. The web server will invoke only the script, while the script takes care of everything else. We place the script as intended in _/apache/bin/php-fcgi-starter/php-fcgi-starter_. 
 The subdirectory isn’t needed, because _suexec_ requires the directory to be owned by the preconfigured user and we don’t want to assign _./bin_ completely to the new user. So, let’s create the subdirectory:
@@ -196,7 +196,7 @@ $> sudo chown fcgi-php:fcgi-php php-fcgi-starter/php-fcgi-starter
 $> sudo chmod +x php-fcgi-starter/php-fcgi-starter
 ```
 
-###Step 7: Creating a PHP test page
+### Step 7: Creating a PHP test page
 
 To finish things off, we should now create a simple _PHP-based_ test page: _/apache/htdocs/info.php_.
 
@@ -206,7 +206,7 @@ phpinfo();
 ?>
 ```
 
-###Step 8: Trying it out
+### Step 8: Trying it out
 
 That was everything. We can now start our web server and try it out.
 
@@ -236,7 +236,7 @@ Here again is a summary of the relevant files and their owners:
 
 Of note is the _suid bit_ on the _suexec binary_.
 
-###Step 9 (Goodie): A little performance test
+### Step 9 (Goodie): A little performance test
 
 Compared to Apache with integrated _PHP_, the application server built here is very high performance. A little performance test can illustrate this. We start our web server in _daemon mode_ and use ApacheBench to put it to the test it with 5 users. The _-l_ option is new. It instructs the tool to ignore deviations in the length of the responses. This is because the page is generated dynamically and the content, as well as its length, will of course be a bit different now and then. We again quit the server following the performance test.
 
@@ -311,7 +311,7 @@ That‘s 389 dynamic requests per second. Which is a lot. Especially considering
 What’s remarkable isn’t the speed of the system, it’s memory usage. Unlike an application server with integrated _PHP module_, we have separated the _PHP stack_ here. This gives us an Apache web server able to use _Event MPM_. In an integrated setup we would have to use the _Prefork MPM_, which works with memory-intensive server processes and not server threads. And each of these processes would then have to load the _PHP module_, regardless of the fact that most requests are normally attributed to static application components such as images, _CSS_, _JavaScripts_, etc.
 On my test system each _Prefork Apache process_, including _PHP_, brings a _resident size_ of 6 MB. An event process with only _4 MB_ means a substantial difference. And outside of this, the number of external _FCGI processes_ will remain significantly smaller.
 
-###References
+### References
 
 * Apache: http://httpd.apache.org
 * Apache FCGI: http://httpd.apache.org/mod_fcgid

--- a/tutorial-4/README.md
+++ b/tutorial-4/README.md
@@ -1,14 +1,14 @@
-##Enabling Encryption with SSL/TLS
+## Enabling Encryption with SSL/TLS
 
-###What are we doing?
+### What are we doing?
 
 We are setting up an Apache web server secured by a server certificate.
 
-###Why are we doing this?
+### Why are we doing this?
 
 The HTTP protocol uses plain text, which can easily be spied on. The HTTPS extension surrounds HTTP traffic in a protective SSL/TLS layer, preventing snooping and ensuring that we are really talking to the server we entered in the URL. All data is sent encrypted. This still doesn’t mean that the web server is secure, but it is the basis for secure HTTP traffic.
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling an Apache web server)](https://www.netnea.com/cms/apache-tutorial-1_compiling-apache/).
 * Understanding of the minimal configuration in [Tutorial 2 (Configuring a minimal Apache server)](http://www.netnea.com/cms/apache-tutorial-2_minimal-apache-configuration).
@@ -17,7 +17,7 @@ First, we are going to enable the server to use SSL with a self-signed certifica
 
 This whole series of tutorials is meant as a guide to a successful lab setup. The idea is to really, really understand Apache. This tutorial is a bit of an exception, as we need to be accessible from the internet in order to get the signed certificate. Later tutorials will return to the lab setup though.
 
-###Step 1: Configuring a server using SSL/TLS, but without an officially signed certificate
+### Step 1: Configuring a server using SSL/TLS, but without an officially signed certificate
 
 The inner working of the _SSL-/TLS_-protocol is complex. The free _OpenSSL Cookbook_ by Ivan Ristić (see links below) explains this topic. His bigger work _Bulletproof SSL and TLS_, which explains the trust relationships in great detail, is another good introduction. The minimal knowledge required can be found in this tutorial though.
 
@@ -142,7 +142,7 @@ The _STS_-header is the most prominent from a group of newer security related he
 That's all the changes to our configuration. Time to start the server!
 
 
-###Step 2: Trying it out
+### Step 2: Trying it out
 
 ```bash
 $> curl -v https://127.0.0.1/index.html
@@ -212,7 +212,7 @@ Below we will be discussing how to obtain an official certificate, how to instal
 
 
 
-###Step 3: Preparing to get an SSL key and certificate
+### Step 3: Preparing to get an SSL key and certificate
 
 HTTPS adds an SSL layer to the familiar HTTP protocol. Technically, SSL (_Secure Socket Layer_) has been replaced by TLS (_Transport Security Layer_), but people still refer to it as SSL. The protocol guarantees encryption and thus data traffic is secured from eavesdropping. Traffic is encrypted symmetrically, guaranteeing greater performance, but in the case of HTTPS requires a public/private key setup for the exchange of symmetric keys by previously unknown communication partners. This public/private key handshake is done by using a server certificate which must be signed by an official authority. The handshake is thus meant to extend browser's trust in the signing authority to the webserver being contacted. This is being done with the help of a chain of trust over multiple certificates.
 
@@ -261,7 +261,7 @@ This defines the path of the token, that `getssl` will place in the file system 
 
 Outside of our domain name, we have entered an alternate name in the variable `SANS`. _Let's Encrypt_ will check both names and it will place an individual token for both names. We can handle this by entering the same path twice under `acl`, or we can enable the variable `USE_SINGLE_ACL`, which is much more elegant.
 
-###Step 4: Getting the SSL key and certificate
+### Step 4: Getting the SSL key and certificate
 
 Let's start our call to _Let's Encrypt_:
 
@@ -471,7 +471,7 @@ SSLCertificateFile      /etc/ssl/certs/christian-folini.ch.crt
 SSLCertificateChainFile /etc/ssl/certs/lets-encrypt-chain.crt
 ```
 
-###Step 5: Examining the chain of trust
+### Step 5: Examining the chain of trust
 
 Before we can start using the browser or curl to call our server, it is a good practice to check the chain of trust and to make sure the encryption is properly configured. Let's start the server and check it out. We will use the command line tool `openssl` again. It really shines with all the options it has. However, _OpenSSL_ does not have a list of known and trusted certificate authorities. We have to tell the tool about the _Let's Encrypt_ certificate authority and its root certificate respectively. We will fetch it from _Let's Encrypt_ and we will then call `openssl` with the root CA as a parameter:
 
@@ -610,7 +610,7 @@ The first few lines are very important as they list the chain. Of equal importan
 
 If we examine the chain on top carefully, we will see that _Let's Encrypt_ is depending on an additional  certificate authority. This is necessary as _Let's Encrypt_ is a very young certificate authority and it has not yet found its way into all browsers. This forces _Let's Encrypt_ to have it's certificate signed by a different certificate authority known to the browser.
 
-###Step 6: Enhancing the Apache configuration a bit
+### Step 6: Enhancing the Apache configuration a bit
 
 All of the preparations are now completed and we can do the final configuration of the web server. I won’t be giving you the complete configuration here, but only the specific server name and the tweaked SSL section:
 
@@ -671,7 +671,7 @@ SSLSessionTickets       Off
 Of course, this adjustment will have consequences in terms of performance. You will see a small drop of throughput on the server, but the clients will encounter bigger latency, as the SSL/TLS handshake has to be performed anew and from scratch. So it is again a trade off between reducing your attack surface and performance: Most people leave the caching in place and I think this is generally a good practice.
 
 
-###Step 7: Trying it out
+### Step 7: Trying it out
 
 Now that we are sure to own an officially signed certificate with a valid chain of trust and now that we understand all the other configuration options in detail, we can turn to the browser and call the domain we configured. In my case, this is [https://www.christian-folini.ch](https://www.christian-folini.ch).
 
@@ -680,7 +680,7 @@ Now that we are sure to own an officially signed certificate with a valid chain 
 The browser confirms, this is a secure connection.
 
 
-###Step 8: Fetching the certificate via Cron from Let's Encrypt
+### Step 8: Fetching the certificate via Cron from Let's Encrypt
 
 _Let's Encrypt_ creates the certificates for a period of 90 days per default. This means we will have to perform the manual call as outlined above every three months. This can be automated, though. As the `getssl` process needs to access the certificate key, the process has to operate as the `root` user. Additionally, the certificate authority _Let's Encrypt_ has to be called via the internet. As a matter of fact, this means that we have to tell `root` to access the internet. This is not without risks and has to be considered carefully.
 
@@ -705,7 +705,7 @@ With this, the signing and renewal of the certificate is fully automated and we 
 
 Interestingly, there is something like a checking instance in the internet, where you can have your _HTTPS_-server examined. Let's try this out as a goodie.
 
-###Step 9 (Goodie): Checking the quality of SSL externally
+### Step 9 (Goodie): Checking the quality of SSL externally
 
 Ivan Ristić, mentioned above as the author of several books on Apache and SSL, launched an analysis service that checks _SSL web servers_. He has sold the site to Qualys in the meantime, but it is still being maintained and actively expanded. It is available at [www.ssllabs.com](https://www.ssllabs.com/ssldb/index.html). A web server configured like the one above earned me the highest grade of _A+_ on the test.
 
@@ -713,7 +713,7 @@ Ivan Ristić, mentioned above as the author of several books on Apache and SSL, 
 
 The highest grade is attainable by following these instructions.
 
-###References
+### References
 
 * [Wikipedia OpenSSL](http://de.wikipedia.org/wiki/Openssl)
 * [OpenSSL Cookbook](https://www.feistyduck.com/books/openssl-cookbook/)

--- a/tutorial-5/README.md
+++ b/tutorial-5/README.md
@@ -1,16 +1,16 @@
-##Extending and analyzing the access log
+## Extending and analyzing the access log
 
-###What are we doing?
+### What are we doing?
 
 We are defining a greatly extended log format in order to better monitor traffic.
 
 
-###Why are we doing this?
+### Why are we doing this?
 
 In the usual configuration of the Apache web server a log format is used that logs only the most necessary information about access from different clients. In practice, additional information is often required, which can easily be recorded in the server's access log. 
 
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling Apache)](https://www.netnea.com/cms/apache-tutorial-1_compiling-apache/).
 * Understanding of the minimal configuration in [Tutorial 2 (Configuring a Minimal Apache Web Server)](https://www.netnea.com/cms/apache-tutorial-2_minimal-apache-configuration/).
@@ -18,7 +18,7 @@ In the usual configuration of the Apache web server a log format is used that lo
 
 
 
-###Step 1: Understanding the common log format
+### Step 1: Understanding the common log format
 
 The _common_ log format is a very simple format that is hardly ever used any more. It has the advantage of being space-saving and hardly ever writing unnecessary information.
 
@@ -90,7 +90,7 @@ One typical example would be a request that causes an error on the server (Statu
 _%b_ is the last element of the _common_ log format. It shows the number of bytes announced in the content-length response headers. In a request for _http://www.example.com/index.html_ this value is the size of the _index.html_ file. The _response headers_ also transmitted are not counted. And there is an additional problem with this number: It is a calculation by the webserver and not an account of the bytes that have actually been sent in the response.
 
 
-###Step 2: Understanding the combined log format
+### Step 2: Understanding the combined log format
 
 The most widespread log format, _combined_, is based on the _common_ log format, extending it by two items.
 
@@ -105,7 +105,7 @@ _"%{Referer}i"_ is used for the referrer. It is output in quotes. The referrer m
 Finally, _"%{User-Agent}i"_ means the client user agent, which is also placed in quotes. This is also a value controlled by the client and which we should not rely on too much. The user agent is the client browser software, normally including the version, the rendering engine, information about compatibility with other browsers and various installed plugins. This results in very long user agent entries which can in some cases include so much information that an individual client can be uniquely identified, because they feature a particular combination of different add-ons of specific versions.
 
 
-###Step 3: Enabling the Logio and Unique-ID modules
+### Step 3: Enabling the Logio and Unique-ID modules
 
 We have become familiar with the _combined_ format, the most widespread Apache log format. However, to simplify day-to-day work, the information shown is just not enough. Additional useful information has to be included in the log file.
 
@@ -123,7 +123,7 @@ LoadModule              unique_id_module        modules/mod_unique_id.so
 We need this module to be able to write two values. _IO In_ and _IO Out_. This means the total number of bytes of the HTTP request including header lines and the total number of bytes in the response, also including header lines. The Unique-ID module is calculating a unique identifier for every request. We'll return to this later on.
 
 
-###Step 4: Configuring the new, extended log format
+### Step 4: Configuring the new, extended log format
 
 We are now ready for a new, comprehensive log format. The format also includes values that the server is as of yet unaware of with the modules defined up to now. It will leave them empty or show them as a hyphen _"-"_. Only with the _Logio_ module just enabled this won’t work. The server will crash if we request these values without them being present.
 
@@ -148,7 +148,7 @@ CustomLog		logs/access.log extended
 ```
 
 
-###Step 5: Understanding the new, extended log format
+### Step 5: Understanding the new, extended log format
 
 The new log format adds 19 values to the access log. This may seem excessive at first glance, but there are in fact good reasons for all of them and having these values available in day-to-day work makes it a lot easier to track down errors.
 
@@ -187,7 +187,7 @@ We’ll continue with performance data. In the future we will be using a stopwat
 And, last but not least, there are other values provided to us by the _OWASP ModSecurity Core Rule Set_ (to be handled in a subsequent tutorial), specifically the anomaly score of the request and the response. For the moment it's not important to know all of this. What’s important is that this highly extended log format gives us a foundation upon which we can build without having to adjust the log format again.
 
 
-###Step 6: Writing other request and response headers to an additional log file
+### Step 6: Writing other request and response headers to an additional log file
 
 In day-to-day work you are often looking for specific requests or you are unsure of which requests are causing an error. It has often been shown to be useful to have specific additional values written to the log file. Any request and response headers or environment variables can be easily written. Our log format makes extensive use of it.
 
@@ -216,7 +216,7 @@ $> cat logs/access-debug.log
 This is how log files can be very freely defined in Apache. What’s more interesting is analyzing the data. But we’ll need some data first.
 
 
-###Step 7: Trying it out and filling the log file
+### Step 7: Trying it out and filling the log file
 
 Let’s configure the extended access log in the _extended_ format as described above and work a bit with the server.
 
@@ -295,7 +295,7 @@ It may take a moment to process this line. As a result we see the following entr
 As predicted above, a lot of values are still empty or indicated by _-_. But we see that we talked to server _www.example.com_ on port 443 and that the size of the request increased with every _POST_ request, with it being almost 4K, or 4096 bytes, in the end. Simple analyses can already be performed with this simple log file.
 
 
-###Step 8: Performing simple analyses using the extended log format
+### Step 8: Performing simple analyses using the extended log format
 
 If you take a close look at the example log file you will see that the duration of the requests are not evenly distributed and that there is a single outlier. We can identify the outlier as follows:
 
@@ -517,7 +517,7 @@ $> cat tutorial-5-example-access.log | alsslprotocol | sucs
 This is now a simple command that is easy to remember and easy to write. We now have a look at the numerical ratio of 1764 to 8150. We have a total of exactly 10,000 requests; the percentage values can be derived by looking at it. In practice however log files may not counted so easily, we will thus be needing help calculating the percentages.
 
 
-###Step 10: Analyses using percentages and simple statistics
+### Step 10: Analyses using percentages and simple statistics
 
 What we are lacking is a command that works similar to the _sucs_ alias, but converts the number values into percentages in the same pass: _sucspercent_. It’s important to know that this script is based on an expanded *awk* implementation (yes, there are several). The package is normally named *gawk* and it makes sure that the `awk` command uses the Gnu awk implementation.
 
@@ -650,7 +650,7 @@ We now sequentially place the paths into variable _P_ and use _while_ to make a 
 This brings us to the end of this tutorial. The goal was to introduce an expanded log format and to demonstrate working with the log files. In doing so, we repeatedly used a series of aliases and two _awk_ scripts, which can be chained in different ways. With these tools and the necessary experience in their handling you will be able to quickly get at the information available in the log files.
 
 
-###References
+### References
 
 * [Apache Module mod_log_config documentation](http://httpd.apache.org/docs/current/mod/mod_log_config.html)
 * [Apache Module mod_ssl documentation](http://httpd.apache.org/docs/current/mod/mod_ssl.html)

--- a/tutorial-6/README.md
+++ b/tutorial-6/README.md
@@ -1,21 +1,21 @@
-##Embedding ModSecurity 
+## Embedding ModSecurity 
 
-###What are we doing?
+### What are we doing?
 We are compiling the ModSecurity module, embedding it in the Apache web server, creating a base configuration and dealing with _false positives_ for the first time.
 
-###Why are we doing this?
+### Why are we doing this?
 
 ModSecurity is a security module for the web server. The tool enables the inspection of both the request and the response according to predefined rules. This is also called a _Web Application Firewall_. It gives the administrator direct control over the requests and the responses passing through the system. The module also provides new options for monitoring, because the entire traffic between client and server can be written 1:1 to the hard disk. This helps with debugging.
 
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling Apache)](https://www.netnea.com/cms/apache-tutorial-1_compiling-apache/).
 * Understanding of the minimal configuration in [Tutorial 2 (Configuring a Minimal Apache Web Server)](https://www.netnea.com/cms/apache-tutorial-2_minimal-apache-configuration/).
 * An Apache web server with SSL/TLS support as in [Tutorial 4 (Enabling Encryption with SSL/TLS)](https://www.netnea.com/cms/apache-tutorial-4_configuring-ssl-tls/).
 * An expanded access log and a set of shell aliases as discussed in [Tutorial 5 (Extending and analyzing the access log)](https://www.netnea.com/cms/apache-tutorial-5/apache-tutorial-5_extending-access-log/)
 
-###Step 1: Downloading the source code and verifying the checksum
+### Step 1: Downloading the source code and verifying the checksum
 
 We previously downloaded the source code for the web server to <i>/usr/src/apache</i>. We will now be doing the same with ModSecurity. To do so, we create the directory <i>/usr/src/modsecurity/</i> as root, we transfer it to ourselves and then download the code into the folder. 
 
@@ -39,7 +39,7 @@ We expect the following response:
 modsecurity-2.9.2.tar.gz: OK
 ```
 
-###Step 2: Unpacking and configuring the compiler
+### Step 2: Unpacking and configuring the compiler
 
 We now unpack the source code and initiate the configuration. But before this it is essential to install several packages that constitute the prerequisite for compiling _ModSecurity_. If you did the first tutorial in this series, you should be covered, but it's still worth checking the following list of packages is really ready: A library for parsing XML structures, the base header files of the system’s own Regular Expression Library and everything to work with JSON files. Like in the previous tutorials, we are working on a system from the Debian family. The packages are thus named as follows:
 
@@ -60,7 +60,7 @@ $> ./configure --with-apxs=/apache/bin/apxs \
 
 We created the <i>/apache</i> symlink in the tutorial on compiling Apache. This again comes to our assistance, because independent from the Apache version being used, we can now have the ModSecurity configuration always work with the same parameters and always get access to the current Apache web server. The first two options establish the link to the Apache binary, since we have to make sure that ModSecurity is working with the right API version. The _with-pcre_ option defines that we are using the system’s own _PCRE-Library_, or Regular Expression Library, and not the one provided by Apache. This gives us a certain level of flexibility for updates, because we are becoming independent from Apache in this area, which has proven to work in practice. It requires the first installed _libpcre3-dev_ package.
 
-###Step 3: Compiling
+### Step 3: Compiling
 
 Following this preparation compiling should no longer pose a problem.
 
@@ -69,7 +69,7 @@ $> make
 ```
 
 
-###Step 4: Installing
+### Step 4: Installing
 
 Installation is also easily accomplished. Since we continue to be working on a test system, we transfer ownership of the installed module from the root user to ourselves, because for all of the Apache binaries we made sure to be the owner ourselves. This in turn produces a clean setup with uniform ownerships.
 
@@ -80,7 +80,7 @@ $> sudo chown `whoami` /apache/modules/mod_security2.so
 
 The module has the number <i>2</i> in its name. This was introduced in the version jump to 2.0 when a reorientation of the module made this necessary. But this is only an minor detail.
 
-###Step 5: Creating the base configuration
+### Step 5: Creating the base configuration
 
 We can now commence setting up a base configuration. ModSecurity is a module loaded by Apache. For this reason it is configured in the Apache configuration. Normally, it is proposed to configure ModSecurity in its own file and then to reload it as an <i>include</i>. We will however only be doing this with a part of the rules (in a subsequent tutorial). We will be pasting the base configuration into the Apache configuration to always keep it in view. In doing so, we will be expanding on our base Apache configuration. You can of course also combine this configuration using the <i>SSL setup</i> and the <i>application server setup</i>. For simplicity’s sake we won’t be doing the latter here. But we are embedding the extended log format that we became familiar with in the 5th tutorial. For this we are adding an additional, optional performance log that will help us find speed bottlenecks. 
 
@@ -437,7 +437,7 @@ Perf-ModSecCombined: %{PERF_COMBINED}M" perflog
 
 This long list of numbers can be used to very well narrow down ModSecurity performance problems and rectify them if necessary. When you need to look even deeper, the _debug log_ can help, or make use of the *PERF_RULES* variable collection, which is well explained in the reference manual.
 
-###Step 6: Writing simple blacklist rules
+### Step 6: Writing simple blacklist rules
 
 ModSecurity is set up and configured using the configuration above. It can diligently log performance data, but only the rudimentary basis is present on the security side. In a subsequent tutorial we will be embedding the _OWASP ModSecurity Core Rules_, a comprehensive collection of rules. But it’s important for us to first learn how to write rules ourselves. Some rules have already been explained in the base configuration. It's just another small step from here.
 
@@ -452,7 +452,7 @@ We start off the rule using _SecRule_. Then we say that we want to inspect the p
 
 We call this type of rules _blacklist rules_, because it describes what we want to block. In principle, we let everything pass, except for requests that violate the configured rules. The opposite approach of describing the requests we want and by doing so block all unknown requests is what we call _whitelist rules_. _Blacklist rules_ are easier to write, but often remain incomplete. _Whitelist rules_ are more comprehensive and when written correctly can be used to completely seal off a server. But they are difficult to write and in practice often lead to problems if they are not fully formulated. A _whitelist example_ follows below.
 
-###Step 7: Trying out the blockade
+### Step 7: Trying out the blockade
 
 Let’s try out the blockade:
 
@@ -487,7 +487,7 @@ Here, _ModSecurity_ describes the rule that was applied and the action taken: Fi
 
 We will also find more details about this information in the _audit log_ discussed above. However, for normal use the _error log_ is often enough.
 
-###Step 8: Writing simple whitelist rules
+### Step 8: Writing simple whitelist rules
 
 Using the rules described in Step 7, we were able to prevent access to a specific URL. We will now be using the opposite approach: We want to make sure that only one specific URL can be accessed. In addition, we will only be accepting previously known _POST parameters_ in a specified format. This is a very tight security technique which is also called positive security: It is no longer us trying to find known attacks in user submitted content, it is now the user who has to proof that his request meets all our criteria.
 
@@ -596,7 +596,7 @@ The case with the password is less obvious. Apparently, we want users to use a l
 
 This concludes our partial whitelisting example.
 
-###Step 9: Trying out the blockade
+### Step 9: Trying out the blockade
 
 But does it really work? Here are some attempts:
 
@@ -657,7 +657,7 @@ more than once"] [tag "Login Whitelist"] [hostname "localhost"] [uri "/login/log
 
 It works from top to bottom and it seems the behaviour is just what we expected.
 
-###Step 10 (Goodie): Writing all client traffic to disk
+### Step 10 (Goodie): Writing all client traffic to disk
 
 Before coming to the end of this tutorial here’s one more tip that often proves useful in practice: _ModSecurity_ is not just a _Web Application Firewall_. It is also a very precise debugging tool. The entire traffic between client and server can be logged. This is done as follows:
 
@@ -702,7 +702,7 @@ The rule that logs traffic can of course be customized, enabling us to precisely
 
 We have reached the end of this tutorial. *ModSecurity* is an important component for the operation of a secure web server. This tutorial has hopefully provided a successful introduction to the topic.
 
-###References
+### References
 
 * Apache [https://httpd.apache.org](http://httpd.apache.org)
 * ModSecurity [https://www.modsecurity.org](http://www.modsecurity.org)

--- a/tutorial-7/README.md
+++ b/tutorial-7/README.md
@@ -1,14 +1,14 @@
-##Including the OWASP ModSecurity Core Rule Set
+## Including the OWASP ModSecurity Core Rule Set
 
-###What are we doing?
+### What are we doing?
 
 We are embedding the OWASP ModSecurity Core Rule Set in our Apache web server and eliminating false alarms.
 
-###Why are we doing this?
+### Why are we doing this?
 
 The ModSecurity Web Application Firewall, as we set up in Tutorial 6, still has barely any rules. The protection only works when you configure an additional rule set. The Core Rule Set provides generic blacklisting. This means that they inspect requests and responses for signs of attacks. The signs are often keywords or typical patterns that may be suggestive of a wide variety of attacks. This also entails false alarms (*false positives*) being triggered and we have to eliminate these for a successful installation.
 
-###Requirements
+### Requirements
 
 * An Apache web server, ideally one created using the file structure shown in [Tutorial 1 (Compiling an Apache web server)](https://www.netnea.com/cms/apache-tutorial-1_compiling-apache/).
 * Understanding of the minimal configuration from [Tutorial 2 (Configuring a minimal Apache server)](https://www.netnea.com/cms/apache-tutorial-2_minimal-apache-configuration/).
@@ -18,7 +18,7 @@ The ModSecurity Web Application Firewall, as we set up in Tutorial 6, still has 
 
 We will be working with the new major release of the Core Rule Set, CRS3; short for Core Rule Set 3.0. The official distribution comes with an _INSTALL_ file that does a good job explaining the setup (after all, yours truly wrote a good deal of that file), but we will tweak the process a bit to suit our needs.
 
-###Step 1: Downloading OWASP ModSecurity Core Rule Set
+### Step 1: Downloading OWASP ModSecurity Core Rule Set
 
 The ModSecurity Core Rule Set are being developed under the umbrella of *OWASP*, the Open Web Application Security Project. The rules themselves are available on *GitHub* and can be downloaded via *git* or with the following *wget* command:
 
@@ -48,7 +48,7 @@ This unpacks the base part of the Core Rule Set in the directory `/apache/conf/o
 The setup file allows us to tweak many different settings. It is worth a look - if only to see what is included. However, we are OK with the default settings and will not touch the file: We just make sure it is available under the new filename `crs-setup.conf`. Then we can continue to update the configuration to include the rules files.
 
 
-###Step 2: Embedding the Core Rule Set
+### Step 2: Embedding the Core Rule Set
 
 In Tutorial 6, in which we embedded ModSecurity itself, we marked out a section for the Core Rule Set. We now add two *Include* directives into this section. Specifically, four parts are added to the existing configuration. (1) The Core Rules base configuration, (2) a part for self-defined rule exclusions before the Core Rules. Then (3) the Core Rules themselves and finally a part (4) for rule exclusions after the Core Rules.
 
@@ -95,7 +95,7 @@ The Core Rule Set comes in blocking mode by default. If a rule is violated and t
 
 The second rule, id `900000`, defines the _Paranoia Level_ to 1. The Core Rules are divided in four groups at paranoia levels 1 - 4. As the name suggests, the higher the paranoia level, the more paranoid the rules. The default is paranoia level 1, where the rules are quite sane and false alarms are rare. When you raise the PL to 2, additional rules are enabled. Starting with PL 2, you will face more and more false alarms, also called false positives. This number grows with PL3 and when you arrive at PL4, you are likely to face false alarms as though your web application firewall has become quite paranoid, so to speak. We will deal with false positives later in this tutorial, but for the moment you just need to be aware that you can control the aggressiveness of the rule set with the paranoia level setting and that PL3 and PL4 are really for advanced users with very high security needs.
 
-###Step 3: A closer look at the rules folder
+### Step 3: A closer look at the rules folder
 
 The center of the previous config snippet follows the include statement, which loads all files with suffix `.conf` from the rules sub folder in the CRS directory. This is where all the rules are being loaded. Let's take a look at them:
 
@@ -396,7 +396,7 @@ DocumentRoot		/apache/htdocs
 
 We have embedded the Core Rule Set and are now ready for a test operation. The rules inspect requests and responses. They will trigger alarms if they encounter fishy requests, but they will not block any transaction, because the limits have been set very high. Let's give it a shot.
 
-###Step 4: Triggering alarms for testing purposes
+### Step 4: Triggering alarms for testing purposes
 
 For starters, we will do something easy. It is a request that will trigger exactly one rule by attempting to execute a bash shell. We know that our simple lab server is not vulnerable to such a blatant attack, but ModSecurity does not know this and will still try to protect us:
 
@@ -466,7 +466,7 @@ $> nikto -h localhost
 
 This scan should have triggered numerous *ModSecurity alarms* on the server. Let’s take a close look at the *Apache error log*. In my case, there were over 7,300 entries in the error log. Combine this with the authorization messages and infos on many 404s (Nikto probes for files that do not exist on the server) and you end up with a fast-growing error log. The single Nikto run resulted in an 8.8 MB logfile. Looking over the audit log tree reveals 78 MB of logs. It's obvious: you need to keep a close eye on these log files or your server will collapse due to denial of service via log file exhaustion.
 
-###Step 5: Analyzing the alert messages
+### Step 5: Analyzing the alert messages
 
 So we are looking at 7,300 alerts. And even if the format of the entries in the error log may be clear, without a tool they are very hard to read, let alone analyze. A simple remedy is to use a few *shell aliases*, which extract individual pieces of information from the entries. They are stored in the alias file we discussed in the log format in Tutorial 5.
 
@@ -634,7 +634,7 @@ $> cat logs/error.log | melidmsg | sucs
 So that's something we can work with. It shows that the Core Rules detected a lot of malicious requests and we now have an idea which rules played a role in this. The rule triggered most frequently, 913120, is no surprise, and when you look upwards in the output, this all makes a lot of sense.
 
 
-###Step 6: Evaluating false alarms
+### Step 6: Evaluating false alarms
 
 So the *Nikto* scan set off thousands of alarms. They were likely justified. In the normal use of *ModSecurity*, things are a bit different. The Core Rule Set is designed and optimized to have as few false alarms as possible in paranoia level 1. But in production use, there are going to be false positives sooner or later. Depending on the application, a normal installation will also see alarms and a lot of them will be false. And when you raise the paranoia level to become more vigilant towards attacks, the number of false positives will also rise. Actually, it will rise steeply when you move to PL 3 or 4; so steeply, some would call it exploding.
 
@@ -735,7 +735,7 @@ The script divides the inbound from the outbound *anomaly scores*. The incoming 
 
 There are probably some *false positives*. In practice, we have to make certain of this before we start fine tuning the rules. It would be totally wrong to assume a false positive based on a justified alarm and suppress the alarm in the future. Before tuning, we must ensure that no attacks are present in the log file. This is not always easy. Manual review helps, restricting to known IP addresses, pre-authentication, testing/tuning on a test system separated from the internet, filtering the access log by country of origin for the IP address, etc... It's a big topic and making general recommendations is difficult. But please do take this seriously.
 
-###Step 7: Handling false positives: Disabling individual rules
+### Step 7: Handling false positives: Disabling individual rules
 
 The simple way of dealing with a *false positive* is to simply disable the rule. We are thus making the alarm disappear by excluding a certain rule from the rule set. The CRS term for this technique is called *Rules Exclusion* or *Exclusion Rules*. It is called *Rule* because this exclusion involved writing rules or directives resembling rules themselves.
 
@@ -790,7 +790,7 @@ As with the startup rule exclusions, we are not limited to an exclusion by rule 
 
 Startup time rule exclusions and runtime rule exclusions have the same effect, but internally, they are really different. With the runtime exclusions, you gain granular control at the cost of performance, as the exclusion is being evaluated for every single request. Startup time exclusions are performing faster and they are easier to read and write.
 
-###Step 8: Handling false positives: Disabling individual rules for specific parameters
+### Step 8: Handling false positives: Disabling individual rules for specific parameters
 
 Next we look at excluding an individual parameter from being evaluated by a specific rule. So unlike our example 920300, which looked at the specific Accept header, we are now targeting rules examining the ARGS group of variables.
 
@@ -841,7 +841,7 @@ This section was very important. Therefore, to summarize once again: We define a
 
 With this, we have seen all basic methods to handle false positives via rule exclusions. You now use the patterns for *excusion rules* described above to work through the various *false positives*. 
 
-###Step 9: Readjusting the anomaly threshold
+### Step 9: Readjusting the anomaly threshold
 
 Handling false positives is tedious at times. However, with the goal of protecting the application, it is most certainly worthwhile. When we introduced the statistic script I stated that we should make sure that at least 99.99% of requests pass through the rule set without any false positives. The remaining positives, the ones caused by attackers, should be blocked. But we are still running with an anomaly limit of 1,000. We need to reduce this to a decent level. Any limit above 30 or 40 is unlikely to stop anything serious. With a threshold of 20, you start to see an effect and then with 10 you get fairly good protection from standard attackers. Even if an individual rule only scores 5 points, some attack classes like SQL injections typically trigger multiple alarms, so a limit of 10 catches quite a few attack requests. In other categories, the coverage with rules is less extensive. This means, the accumulation of multiple rules is less intense. So it is perfectly possible to stay beneath a score of 10 with a certain attack payload. That's why a limit of 5 for the inbound score and 4 for the outbound score gives you a good level security. These are the default values of the CRS.
 
@@ -906,14 +906,14 @@ For the outbound responses, the situation is a bit simpler as you will hardly se
 
 I think the tuning concept and the theory are now quite clear. In the next tutorial, we will continue with tuning false positives to gain some practice with the methods demonstrated here. And I will also introduce a script which helps with the construction of the more complicated exclusion rules.
 
-###Step 10 (Goodie): Summary of the ways of combating false positives
+### Step 10 (Goodie): Summary of the ways of combating false positives
 
 It is possibly best to summarize the tuning directives in a graphic. So here is a cheatsheet for your use!
 
 <a href="https://www.netnea.com/cms/rule-exclusion-cheatsheet-download/"><img src="https://www.netnea.com/files/tutorial-7-rule-exclusion-cheatsheet_small.png" alt="Rule Exclusion CheatSheet" width="476" height="673" /></a>
 
 
-###References
+### References
 - [OWASP ModSecurity Core Rule Set](https://coreruleset.org)
 - [Spider Labs Blog Post: Exception Handling](http://blog.spiderlabs.com/2011/08/modsecurity-advanced-topic-of-the-week-exception-handling.html)
 - [ModSecurity Reference Manual](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual)

--- a/tutorial-9/README.md
+++ b/tutorial-9/README.md
@@ -1,16 +1,16 @@
-##Setting up a reverse proxy server
+## Setting up a reverse proxy server
 
-###What are we doing?
+### What are we doing?
 
 We are configuring a reverse proxy protecting access to the application and shielding the application server from the internet. In doing so, we’ll become familiar with several configuration methods and will be working with ModRewrite for the first time.
 
-###Why are we doing this?
+### Why are we doing this?
 
 A modern application architecture has multiple layers. Only the reverse proxy is exposed to the internet. It conducts a security check on the HTTP payload and forwards the requests found to be good to the application server in the second layer. This in turn is connected to a database server located in yet another layer. This is referred to as a three-tier model. In a staggered defense spanning three levels, the reverse proxy or to be technically correct, the gateway server, provides the first look into the encrypted requests. On the way back it is in turn the last instance in which the responses can be checked one last time.
 
 There are a number of ways for converting an Apache server into a reverse proxy. More importantly, there are multiple ways of communicating with the application server. In this tutorial we will be restricting ourselves to the normal HTTP-based `mod_proxy_http`. We will not be discussing other methods of communication such as FastCGI proxy or AJP here. There are also several ways of getting the proxy process going in Apache. We will start by looking at the normal setup using ProxyPass and will afterwards discuss other options using ModRewrite.
 
-###Requirements
+### Requirements
 
 The following is a recommended set of requirements. You do not really need all of these, but if you follow them diligently, I am sure all the examples will work 1:1. If you take a short cut, it will probably need some tweaking with paths and predefined aliases.
 
@@ -23,7 +23,7 @@ The following is a recommended set of requirements. You do not really need all o
 
 
 
-###Step 1: Preparing the backend
+### Step 1: Preparing the backend
 
 The purpose of a reverse proxy is to shield an application server from direct internet access. As somewhat of a prerequisite for this tutorial, we’ll be needing a backend server like this.
 In principle, any HTTP application can be used for such an installation and we could very well use the application server from the third tutorial. However, it seems appropriate for me to demonstrate a very simple approach. We’ll be using the tool `socat` short for SOcket CAt.
@@ -54,7 +54,7 @@ Server response, port 8000
 
 We have set up a backend system with the simplest of means. So easy, that in the future we might come back to this method to verify that a proxy server is working before the real application server is running.
 
-###Step 2: Enabling the proxy module
+### Step 2: Enabling the proxy module
 
 Several modules are required to use Apache as a proxy server. We compiled them in the first tutorial and can now simply link them.
 
@@ -73,7 +73,7 @@ ProxyRequests Off
 
 This directive actually means forwarding requests to servers on the internet, even if the name indicates a general setting. As mentioned before, the directive is correctly set for Apache 2.4 and it is only being mentioned here to guard against questions or incorrect settings in the future.
 
-###Step 3: ProxyPass
+### Step 3: ProxyPass
 
 This brings us to the actual proxying settings: There are many ways for instructing Apache to forward a request to a backend application. We’ll be looking at each option in turn. The most common way of proxying requests is based on the ProxyPass directive. It is used as follows:
 
@@ -94,13 +94,13 @@ The most important directive is ProxyPass. It defines a `/service1` path and spe
 
 On the next line comes a related directive that despite having a similar name performs only a small auxiliary function. Redirect responses from the backend are fully qualified in http-compliant form. Such as `https://backend.example.com/service1`, for example. The address is however not accessible by the client. For this reason, the reverse proxy has to rewrite the backend’s location header, `backend.example.com`, replacing it with its own name and thus mapping it back to its own namespace. ProxyPassReverse, with such a great name, only has a simple search and replace feature touching the location headers. As already seen in the ProxyPass directive, proxying is again symmetric: the paths are rewritten 1:1. We are free to ignore this rule, but I urgently recommend keeping it, because misunderstandings and confusion lie beyond. In addition to accessing location headers, there is a series of further reverse directives for handling things like cookies. They can be useful from case to case.
 
-###Step 4: Proxy stanza
+### Step 4: Proxy stanza
 
 Continuing on in the configuration: now comes the Proxy block where the connection to the backend is more precisely defined. Specifically, this is where requests are authenticated and authorized. Further below in the tutorial we will also be adding a load balancer to this block.
 
 The proxy block is similar to the location and the directory block we have previously become familiar with in our configuration. These are called containers. Containers specify to the web server how to structure the work. When a container appears in the configuration, it prepares a processing structure for it. In the case of `mod_proxy` the backend can also be accessed without a Proxy container. However, access protection is not taken into account and other directives no longer have any place where it can be inserted. Without the Proxy block the processing of complex servers remains a bit haphazard and it would do us well to configure this part as well. Using the ProxySet directive, we could intervene even more here and specify things like the connection behavior. Min, max and smax can be used to specify the number of threads assigned to the proxy connection pool. This can impact performance from case to case. The keep-alive behavior of the proxy connection can be influenced and a variety of different timeouts defined for it. Additional information is available in the Apache Project documentation.
 
-###Step 5: Defining exceptions when proxying and making other settings
+### Step 5: Defining exceptions when proxying and making other settings
 
 The `ProxyPass` directive we are using has forwarded all requests for `/service1` to the backend. However, in practice it is often the case that you don’t want to forward everything. Let’s suppose there’s a path `/service1/admin` that we don’t want to expose to the internet. This can also be prevented by the appropriate `ProxyPass` setting, where the exception is initiated by using an exclamation mark. What's important is to define the exception before configuring the actual proxy command:
 
@@ -130,7 +130,7 @@ Backend systems often pay less attention to security than a reverse proxy. Error
 ProxyErrorOverride      On
 ```
 
-###Step 6: ModRewrite
+### Step 6: ModRewrite
 
 In addition to the `ProxyPass` directive, the Rewrite module can be used to enable reverse proxy features. Compared to ProxyPass, it enables more flexible configuration. We have not seen ModRewrite up to this point. Since this is a very important module, we should take a good look at it.
 
@@ -204,7 +204,7 @@ The schema we want is now clear. But to the left of it comes a new item. We don�
 
 ModRewrite has been introduced. For further examples refer to the documentation or the sections of this tutorial below where it will become familiar with yet more recipes.
 
-###Step 7: ModRewrite [proxy]
+### Step 7: ModRewrite [proxy]
 
 Let's use ModRewrite to configure a reverse proxy. We do this as follows:
 
@@ -235,7 +235,7 @@ So much for the simple configuration using a rewrite rule. There is no real adva
 
 However, it may now be that we want to use a single reverse proxy to combine multiple backends or to distribute the load over multiple servers. This calls for our own load balancer. We’ll be looking at it in the next section:
 
-###Step 8: Balancer [proxy]
+### Step 8: Balancer [proxy]
 
 We first have to load the Apache load balancer module:
 
@@ -348,7 +348,7 @@ Besides the keep-alive header, the request handler is also of interest. The requ
 
 In a subsequent tutorial we will be seeing that the proxy balancer can also be used in other situations. For the moment we will however be content with what is happening and will now be turning to RewriteMaps. A RewriteMap is an auxiliary structure which again increases the power of ModRewrite. Combined with the proxy server, flexibility rises substantially.
 
-###Step 9: RewriteMap [proxy]
+### Step 9: RewriteMap [proxy]
 
 RewriteMaps come in a number of different variations. They works by assigning a value to a key parameter at every request. A hash table is a simple example. But it is then also possible to configure external scripts as a programmable RewriteMap. The following types of maps are possible:
 
@@ -462,7 +462,7 @@ Connection: close
 
 The different extended header lines are listed sequentially and are filled in with values where present.
 
-###Step 11 (Goodie): Configuration of the complete reverse proxy server
+### Step 11 (Goodie): Configuration of the complete reverse proxy server
 
 This small extension brings us to the end of this tutorial and also to the end of the basic block of different tutorials. Over several tutorials we have seen how to set up an Apache web server for a lab, from compiling it to the basic configuration, and ModSecurity tuning to reverse proxies, gaining deep insight into the how of the server and its most important modules work.
 


### PR DESCRIPTION
See #9.

PR based on @studersi's proposal:

```
find . -wholename "*tutorial-*/README.md" -exec sed -r -i "s/^(#{2,3})([[:alnum:]])/\1\ \2/" '{}' \;
```