### PR TITLE
Add script to generate html and pdf files from markdown.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+html/
+pdf/
 pdfs/

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# Usage: ./generate_docs.sh [token]
+#
+# Description: Generates minimal HTML and PDF files in an output directory using GitHubs markdown API.
+# 	The markdown files are first converted to HTML then the HTML files are converted to PDF.               
+#
+# Note: GitHub's API is rate limited (60 requests per hour). Using an access token from the
+# 	following URL, this rate is increased considerably: https://github.com/settings/tokens/new?scopes=
+# 	More info here: https://github.com/joeyespo/grip#access
+########################################################################################################################
+
+OUT_DIR_HTML=html/
+OUT_DIR_PDF=pdf/
+
+# check if grip installed
+which grip > /dev/null 2> /dev/null
+rc=$?
+if [ ${rc} != 0 ]; then
+	echo "The command 'grip' is not available. Install it with pip:"
+	echo "sudo pip install grip"
+	exit 1
+fi
+
+# check if chromium installed
+which chromium-browser > /dev/null 2> /dev/null
+rc=$?
+if [ ${rc} != 0 ]; then
+	echo "The command 'chromium-browser' is not available. Install it with apt:"
+	echo "sudo apt install chromium-browser"
+	exit 1
+fi
+
+# make sure output directories exists
+mkdir -p ${OUT_DIR_HTML}
+mkdir -p ${OUT_DIR_PDF}
+
+# check if GitHub access token provided
+if [ -n "$1" ]; then
+	token_argument="--pass $1"
+fi
+
+# generate html
+echo -n "Generating html in ${OUT_DIR_HTML} ... "
+for tut in tutorial-*; do
+	grip \
+ 		"${tut}/README.md" ${token_argument} --quiet --export --no-inline ${OUT_DIR_HTML}${tut}.html
+done
+echo "done"
+
+# generate pdf
+echo -n "Generating pdf in ${OUT_DIR_PDF} ... "
+for tut in $(ls ${OUT_DIR_HTML}); do
+	chromium-browser --headless --disable-gpu --print-to-pdf=${OUT_DIR_PDF}${tut}.pdf "${OUT_DIR_HTML}${tut}"
+done
+echo "done"
+
+


### PR DESCRIPTION
This is to address issue #6.

The script generates html files from the markdown source and pdf files from html source.

Note that there are still some issues with this script:
- [ ] HTML files are not styled at all
- [ ] HTML files contain the filename
- [ ] HTML files are missing some images
- [ ] HTML files do not have an index page
- [ ] HTML output directory folder structure does not necessarily correspond to folder structure on website
- [ ] PDF files contain header and footer with metadata from printing
- [ ] PDF files only contain single tutorials, they are not joined into a single file

Some of these problems are fairly easy to address but require decisions to be made first (e.g. how to structure the output directories).